### PR TITLE
Update faraday version

### DIFF
--- a/pepipost_gem.gemspec
+++ b/pepipost_gem.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://apimatic.io'
   s.license = 'MIT'
   s.add_dependency('logging', '~> 2.0')
-  s.add_dependency('faraday', '~> 0.10.0')
+  s.add_dependency('faraday', '~> 0.13')
   s.add_dependency('test-unit', '~> 3.1.5')
   s.add_dependency('certifi', '~> 2016.9', '>= 2016.09.26')
   s.add_dependency('faraday-http-cache', '~> 1.2', '>= 1.2.2')


### PR DESCRIPTION
I ran into an issue recently where due to this library's faraday version being out of to date, my application crashed. Whoever maintains this needs to update this regularly or should change this version definition to be a min version rather than a strict version.