### PR TITLE
allow Ruby 3.x and above

### DIFF
--- a/pepipost_gem.gemspec
+++ b/pepipost_gem.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.add_dependency('test-unit', '~> 3.1', '>= 3.1.5')
   s.add_dependency('certifi', '~> 2016')
   s.add_dependency('faraday-http-cache', '~> 1.2', '>= 1.2.2')
-  s.required_ruby_version = '~> 2.0'
+  s.required_ruby_version = '>= 2.0'
   s.files = Dir['{bin,lib,man,test,spec}/**/*', 'README*', 'LICENSE*']
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
Currently, the SDK does not work with Ruby 3.x which has become the global standard for all modern Ruby applications.
Need to update the gemspec to support this. No change in application code is needed as per my testing.